### PR TITLE
feat: 添加 novel-writer 长篇小说全流程创作 Skill

### DIFF
--- a/.claude/skills/novel-writer/SKILL.md
+++ b/.claude/skills/novel-writer/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: novel-writer
+description: |
+  Self-evolving novel writing workflow for long-form fiction (web novels, serial novels).
+  TRIGGER when conversation involves:
+  - Planning or outlining a novel (chapter plans, volume structure, timeline)
+  - Writing novel chapters (batch writing, expanding, polishing)
+  - Logic review and continuity checking (age/timeline/item consistency)
+  - Chapter title design and renaming
+  - Exporting to publishing platform format (txt files for 番茄小说 etc.)
+  - Any task related to long-form fiction creation or maintenance
+  BEHAVIOR:
+  - Follow the 6-stage pipeline: Planning → Writing → Expansion → Logic Review → Title Design → Export
+  - Use delegate_task for parallel batch writing (3 agents × 5 chapters each)
+  - Always maintain a canonical timeline with character ages and event years
+  - Scan for AI-isms and fix them (下一刻/顿时/不禁/宛如/犹如/仿佛)
+  - Directly modify the publishing-ready txt files, not just source files
+  - After any fix, grep to verify no residual errors
+  - Each chapter targets ~3000 Chinese characters
+allowed-tools: Bash, Read, Write, Edit
+---
+
+## Novel Writing Pipeline
+
+```
+Stage 1: Planning → Stage 2: Batch Writing → Stage 3: Expansion
+                                                      ↓
+Stage 6: Export ← Stage 5: Title Design ← Stage 4: Logic Review
+```
+
+## Selective Loading Protocol
+
+Before starting work, read `references/_index.md` to load relevant knowledge.
+When discovering new writing patterns, pitfalls, or workflow improvements, update the appropriate references/ file.
+
+## Tool Selection
+
+| Need | Tool |
+|------|------|
+| Chapter planning | delegate_task with planning prompt |
+| Batch writing | delegate_task × 3 parallel, 5 chapters each |
+| Character counting | `len([c for c in text if '\u4e00' <= c <= '\u9fff'])` |
+| Logic scanning | search_files with regex patterns |
+| Bulk fixing | execute_code with patch() in loop |
+| File renaming | os.rename() in execute_code |
+
+## Stage 1: Planning
+
+1. Read existing settings, establish **canonical timeline** (character ages, event years)
+2. Generate `chapter-plan-vN.md` per volume with: chapter title (2-6 chars), one-sentence summary, 2+ sensory details, emotional tone, closing image
+3. Structure in 5 acts: Arrival → Rooting → Conflict → Legacy → Departure
+
+**Rules:**
+- Timeline math must be consistent: character_age = birth_year + current_year
+- Adjacent volumes must have different core desire layers
+- Each volume ending needs a "hook" for the next volume
+
+## Stage 2: Batch Writing
+
+1. Write chapters in batches of 5 using delegate_task (max 3 parallel)
+2. Each subagent gets: full character context, writing style rules, 5 chapter plans, output path
+3. Target: 3000 Chinese characters per chapter
+
+**Writing Style Rules (include in every task):**
+```
+- Short sentences, max 40 chars
+- 2+ five-sense details per chapter
+- Restrained emotion - show through actions, not words
+- Dialogue has subtext, not direct statement
+- Chapter endings: concrete image or action, NEVER summary
+- Forbidden words: 下一刻/与此同时/紧接着/心头一震/瞳孔骤缩/空气凝固/不禁/顿时/宛如/犹如/仿佛
+- Forbidden patterns: 不是…而是… stacking, dash explanations, author commentary
+```
+
+## Stage 3: Expansion
+
+1. Scan all chapters for character count
+2. Chapters under 2800 chars need expansion
+3. Expand in batches of 3: read original → add sensory details and scene depth → overwrite
+4. Keep same story and ending, only add depth
+5. Loop until average ≥ 2900 chars/chapter
+
+## Stage 4: Logic Review
+
+1. Establish **canonical facts table** (write to CLAUDE.md or review doc):
+   - Timeline: each key event at what year
+   - Character ages: each character at each time point
+   - Item inventory: key props with count, appearance, origin
+   - Location specs: names, geography, features
+
+2. Batch scan with search_files for contradiction patterns:
+   ```
+   Character ages: [name] + 岁/四十八/四十七/七十三
+   Timing: 两年前/五年前/九年前 + 走了
+   Items: needle count / fan description / badge
+   Modern words: 神经传导/代偿/血液循环/压力/焦虑
+   AI words: 下一刻/顿时/不禁/宛如/犹如/仿佛
+   ```
+
+3. Batch fix with execute_code + patch():
+   ```python
+   fix_rules = [(regex, replacement, description), ...]
+   for pattern, replacement, desc in fix_rules:
+       new = re.sub(pattern, replacement, content)
+       if new != content: write_file(new)
+   ```
+
+4. Re-scan to verify no residuals
+
+**Common Error Patterns:**
+| Error | Example | Fix |
+|-------|---------|-----|
+| Age offset | Character 48 when should be 43 | Align to canonical timeline |
+| Death timing | "2 years ago" vs "5 years ago" | Calculate from canonical |
+| Item count | Needles 12 vs 36 | Unify to setting value |
+| Item description | Fan "landscape" vs "ink plum" | Unify to setting value |
+| Modern terms | "nerve conduction" in dialogue | Use period-appropriate language |
+| English mixed in | "shrugged了一下" | "耸了耸肩" |
+
+**Key principle:** Directly modify the publishing-ready txt files. After each fix, grep to verify no residuals.
+
+## Stage 5: Title Design
+
+1. Read each chapter's content (first 10 lines + title)
+2. Design unified style per volume:
+   - Volume 1: Warm daily life ("柴米药香", "腊月的雪")
+   - Volume 2: Journey imagery ("炊烟", "那条黄狗")
+   - Volume 3: Cultivation world ("东域界碑", "灵气浓雾")
+   - Volume 4: Quiet poetry ("落笔写「周」", "灯花炸开")
+3. Title requirements: 2-6 chars, evocative, no single-character titles
+4. Update file first line AND filename
+
+**Good title techniques:**
+- Objects/images: "银针", "折扇", "灯花"
+- Actions/states: "不回头", "一个人走"
+- Key quotes from text: "就这点东西", "没有回头"
+
+## Stage 6: Export
+
+1. Generate txt from md if needed
+2. Organize by volume:
+   ```
+   NovelName-番茄发布版/
+   ├── 第一卷-卷名/ (001-标题.txt ~ 050-标题.txt)
+   ├── 第二卷-卷名/ (001-标题.txt ~ 050-标题.txt)
+   └── ...
+   ```
+3. txt format: plain text, no markdown, chapter title as first line
+4. Filename: `NNN-章名.txt` (3-digit number)
+
+## Knowledge Evolution Protocol
+
+When discovering new patterns during writing:
+1. Is this a reusable pattern? → Add to references/
+2. Is this a pitfall to avoid? → Add to references/pitfalls.md
+3. Is this a workflow improvement? → Update this SKILL.md
+
+Update references/ with:
+- New writing patterns that work well
+- Common AI-isms to scan for
+- Timeline/age calculation formulas
+- Export format requirements

--- a/.claude/skills/novel-writer/references/_index.md
+++ b/.claude/skills/novel-writer/references/_index.md
@@ -1,0 +1,22 @@
+# Novel Writer Knowledge Index
+
+## references/ Structure
+
+| File | Content | Load When |
+|------|---------|-----------|
+| writing_style.md | Writing rules, forbidden words, style patterns | Starting any writing task |
+| logic_patterns.md | Common contradiction patterns, scan regex, fix templates | Logic review stage |
+| timeline_formulas.md | Age/time calculation formulas, canonical timeline template | Planning and review |
+| export_format.md | txt export rules, filename conventions, directory structure | Export stage |
+
+## Quick Reference
+
+**Character count:** `len([c for c in text if '\u4e00' <= c <= '\u9fff'])`
+
+**Batch writing:** delegate_task × 3 parallel, 5 chapters each, 3000 chars target
+
+**Logic scan patterns:**
+- Ages: `[name]四十八|四十七|七十三|五十`
+- Timing: `两年前|五年前|九年前.*走了`
+- Items: `二十四根|三十六根|十四根|山水|竹林`
+- AI words: `下一刻|顿时|不禁|宛如|犹如|仿佛`

--- a/.claude/skills/novel-writer/references/logic_patterns.md
+++ b/.claude/skills/novel-writer/references/logic_patterns.md
@@ -1,0 +1,72 @@
+# Logic Contradiction Patterns
+
+## Scan Patterns (regex)
+
+### Character Ages
+```python
+patterns = {
+    'character_age': r'谷雨(四十八|四十七|七十三|五十)岁?',
+    'mentor_age': r'(七十岁|七十一岁|七十四岁|七十九)的人了',
+    'practice_years': r'行医三十年(?!二)',
+    'death_timing': r'(两年前|九年前)走了',
+    'side_char_age': r'(五十三)了吧',
+}
+```
+
+### Items
+```python
+patterns = {
+    'needle_count': r'(二十四根|三十六根|十四根针|一套九根)',
+    'fan_desc': r'扇面.*(山水|竹林)',  # Should be 墨梅
+    'infant_error': r'襁褓里的婴儿',
+    'wrong_age_start': r'(十五岁|十六岁).*学医',
+}
+```
+
+### AI-isms
+```python
+patterns = {
+    'ai_words': r'(下一刻|与此同时|紧接着|心头一震|瞳孔骤缩|空气凝固|不禁|顿时|宛如|犹如)',
+    'ai_仿佛': r'仿佛',  # Max 1 per chapter
+    'author_commentary': r'(他意识到|显然|毫无疑问|这意味着|由此可见)',
+}
+```
+
+### Modern Language
+```python
+patterns = {
+    'medical_terms': r'(神经传导|生理功能|代偿|肩袖损伤|血液循环|退行性病变)',
+    'psychological': r'(焦虑|压力大|抑郁)',
+    'english_mix': r'[a-zA-Z]+',  # Check context, may be false positive
+}
+```
+
+## Fix Template
+```python
+fix_rules = [
+    # (regex_pattern, replacement, description)
+    (r'谷雨四十八', '谷雨四十三', 'Guyu age at departure: 48→43'),
+    (r'行医三十年', '行医三十二年', 'Practice years: 30→32'),
+    (r'两年前走了', '五年前走了', 'Death timing: 2→5 years ago'),
+    (r'五十三了吧', '三十七了吧', 'Ma Sanjin reunion age: 53→37'),
+    (r'享年七十三岁', '享年五十岁', 'Guyu death age: 73→50'),
+    (r'二十四根银针', '十二根银针', 'Needle count: 24→12'),
+    (r'扇面.*山水', '扇面画着一枝墨梅', 'Fan: landscape→ink plum'),
+    (r'襁褓里的婴儿', '瘦弱的小丫头', 'A-Luo: infant→thin girl'),
+    (r'从九岁长到', '从七岁长到', 'A-Luo start age: 9→7'),
+    (r'二十年下来', '三十年下来', 'Valley duration: 20→30 years'),
+]
+
+import re
+for path, content in files:
+    original = content
+    for pattern, replacement, desc in fix_rules:
+        content = re.sub(pattern, replacement, content)
+    if content != original:
+        write(path, content)
+```
+
+## False Positive Filters
+- "七十三岁" + "中风" in same file → patient record, NOT character age
+- "山水" + "墙上挂" → wall painting, NOT folding fan
+- "行医三十年" in early chapters (year 0) → round number, acceptable

--- a/.claude/skills/novel-writer/references/timeline_formulas.md
+++ b/.claude/skills/novel-writer/references/timeline_formulas.md
@@ -1,0 +1,43 @@
+# Timeline & Age Formulas
+
+## Canonical Timeline Template
+
+| Event | Year | Character Age | Notes |
+|-------|------|---------------|-------|
+| Story start | 0 | - | Protagonist arrives |
+| Key event 1 | X | Age = birth_year + X | |
+| Key event 2 | Y | Age = birth_year + Y | |
+| Story end | Z | Age = birth_year + Z | |
+
+## Age Calculation Rules
+
+```
+character_age_at_event = birth_year + event_year
+years_between_events = event_year_B - event_year_A
+years_since_event = current_year - event_year
+```
+
+## Common Mistakes
+
+1. **Round number drift**: "三十年" used when actual is 32 years → always calculate exact
+2. **Death timing**: "X年前" must equal (current_year - death_year), not estimated
+3. **Adoption age**: adopted_age + years_since_adoption = current_age
+4. **Two lifetimes**: current_life_age + previous_life_age = total_lived_years
+
+## Validation Formula
+
+For each character reference in text:
+```python
+assert stated_age == (birth_year + chapter_year), f"Age mismatch: stated={stated_age}, calculated={birth_year + chapter_year}"
+```
+
+## Timeline Integrity Check
+
+```python
+# For each chapter, verify all age references
+for chapter in chapters:
+    for name, stated_age in extract_ages(chapter):
+        expected = BIRTH_YEAR[name] + CHAPTER_YEAR[chapter]
+        if stated_age != expected:
+            flag_error(chapter, name, stated_age, expected)
+```

--- a/.claude/skills/novel-writer/references/writing_style.md
+++ b/.claude/skills/novel-writer/references/writing_style.md
@@ -1,0 +1,37 @@
+# Writing Style Rules
+
+## Sentence Rules
+- Max 40 Chinese characters per sentence
+- Short fragments for emphasis: "很安静。" "没人说话。"
+- No mechanical triple-sentence patterns (他X。他Y。他Z。)
+- No stacking parallel structures
+
+## Sensory Rules
+- Minimum 2 five-sense details per chapter
+- Cover: touch, smell, sound, taste, sight
+- Ground every scene in physical sensation
+
+## Emotion Rules
+- NEVER directly write: 愤怒/紧张/害怕/震惊
+- Show through: breathing, hand trembling, silence, speech pace, action mistakes
+- Allow short internal utterances: "完了" "妈的" — next sentence must be action
+
+## Dialogue Rules
+- Characters don't say what they mean (subtext)
+- Character-specific voices: Gu = concise/silent, Ma Sanjin = loud/warm, Daoist = cryptic
+- Minimize "他说道" "她回答道"
+
+## Chapter Ending Rules
+- Concrete image or action, NEVER summary
+- No moral/lesson at end
+- No "总之" "说到底" "他意识到"
+
+## Forbidden Words
+下一刻, 与此同时, 紧接着, 心头一震, 瞳孔骤缩, 空气凝固, 不禁, 顿时, 宛如, 犹如, 仿佛
+
+## Forbidden Patterns
+- 不是…而是… stacking
+- Dash — explanations (use short sentences instead)
+- Author commentary: 他意识到/显然/毫无疑问/这意味着/由此可见
+- 不仅仅是...更是...
+- Modern vocabulary in period settings


### PR DESCRIPTION
## 新增 Skill: novel-writer

一个完整的长篇小说创作全流程 Skill，来源于《人间长生》200章长篇小说的实战经验。

### 六阶段管线

```
大纲规划 → 批量写作 → 字数扩充 → 逻辑审查 → 章名重设计 → 导出发布版
```

### 文件结构

```
.claude/skills/novel-writer/
├── SKILL.md                          # 完整六阶段工作流
└── references/
    ├── _index.md                     # 知识索引
    ├── writing_style.md              # 写作风格规范和禁用词
    ├── logic_patterns.md             # 逻辑矛盾扫描正则和修复模板
    └── timeline_formulas.md          # 时间线/年龄计算公式
```

### 核心能力

1. **批量并行写作**: delegate_task × 3 并行，5章/批，3000字/章目标
2. **逻辑审查**: 正则扫描20+种矛盾模式，批量修复
3. **章名重设计**: 2-6字意象化章名，按卷统一风格
4. **发布版导出**: 按卷分目录，纯txt格式，番茄小说直接上传

### 来源

从创作200章、50万字长篇小说《人间长生》的过程中提炼而成。